### PR TITLE
fix: revert header to old version, keep theme toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -34,11 +34,6 @@
     </button>
 
     <div class="container">
-        <header>
-            <h1>Course Materials Assistant</h1>
-            <p class="subtitle">Ask questions about courses, instructors, and content</p>
-        </header>
-
         <div class="main-content">
             <!-- Left Sidebar -->
             <aside class="sidebar">

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -66,26 +66,6 @@ body {
     padding: 0;
 }
 
-/* Header - Hidden */
-header {
-    display: none;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
 
 /* Main Content Area with Sidebar */
 .main-content {
@@ -753,15 +733,7 @@ details[open] .suggested-header::before {
     .chat-main {
         order: 1;
     }
-    
-    header {
-        padding: 1rem;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
-    }
-    
+
     .chat-messages {
         padding: 1rem;
     }


### PR DESCRIPTION
Fixes #2

This PR reverts the header to the old version by removing the new header elements while preserving the theme toggle functionality.

**Changes:**
- Removed "Course Materials Assistant" header title
- Removed "Ask questions about courses, instructors, and content" subtitle
- Removed horizontal row below subheader
- Cleaned up unused header CSS styles
- Preserved theme toggle button (top-right corner)

**Files modified:**
- `frontend/index.html`
- `frontend/style.css`

----

Generated with [Claude Code](https://claude.ai/code)